### PR TITLE
ci: modify concurrency configuration in PR check and deploy workflow

### DIFF
--- a/.github/workflows/Pull Request Check and Deploy Preview.yml
+++ b/.github/workflows/Pull Request Check and Deploy Preview.yml
@@ -20,9 +20,11 @@ on:
       - closed
 
 concurrency:
-  group: preview-${{ github.event_name }}-${{ github.event.number || github.ref_name }}
-  cancel-in-progress: true
-
+  # 针对远程部署库，无法同时部署多个preview 添加并行限制
+  # group: preview-${{ github.event_name }}-${{ github.event.number || github.ref_name }}
+  # cancel-in-progress: true
+  group: cnjimbo/preview
+  cancel-in-progress: false
 jobs:
   dev:
     name: Development


### PR DESCRIPTION
Change the concurrency group to a fixed name and disable in-progress cancellation for the 'Pull Request Check and Deploy Preview' workflow. This update ensures that multiple previews cannot be deployed simultaneously to the same remote repository.