### PR TITLE
chore(github-actions): update default values for workflow retention

### DIFF
--- a/.github/workflows/delete-workflows.yml
+++ b/.github/workflows/delete-workflows.yml
@@ -10,11 +10,11 @@ on:
       days:
         description: Number of days.
         required: true
-        default: "0"
+        default: 1
       minimum_runs:
         description: The minimum runs to keep for each workflow.
         required: true
-        default: "1"
+        default: 1
       delete_workflow_pattern:
         description: The name or filename of the workflow. if not set then it will target all workflows.
         required: false


### PR DESCRIPTION
Increase the default number of days for workflow retention from 0 to 1 and ensure the minimum runs to keep for each workflow are specified as 1 instead of a string value. This change optimizes the configuration for GitHub Actions workflow management.