### PR TITLE
chore(github-actions): expand pull request trigger events

### DIFF
--- a/.github/workflows/Pull Request Check and Deploy Preview.yml
+++ b/.github/workflows/Pull Request Check and Deploy Preview.yml
@@ -14,10 +14,23 @@ on:
   delete:
   pull_request_target:
     types:
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
       - opened
-      - synchronize
+      - edited
+      # - closed
       - reopened
-      - closed
+      - synchronize
+      - converted_to_draft
+      - ready_for_review
+      - locked
+      - unlocked
+      - review_requested
+      - review_request_removed
+      - auto_merge_enabled
+      - auto_merge_disabled
 
 concurrency:
   # 针对远程部署库，无法同时部署多个preview 添加并行限制


### PR DESCRIPTION
Extend the GitHub Actions workflow to trigger on more pull request events, including assigned, unassigned, labeled, unlabeled, opened, synchronize, edited, converted_to_draft, ready_for_review, locked, unlocked, review_requested, review_request_removed, auto_merge_enabled, and auto_merge_disabled.

This ensures that the 'Pull Request Check and Deploy Preview' workflow is triggered by a broader range of pull request activities, streamlining the development and review process.