### PR TITLE
docs(readme): update blog title and descriptions, clean up content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<h1 align="center"> 粥里有勺糖 </h1>
-<p align="center">你的指尖,拥有改变世界的力量</p>
+<h1 align="center"> 代码收容所 </h1>
+<p align="center">天道酬勤，恒以致遠</p>
 <p align="center">博客主题：<a href="https://theme.sugarat.top/" target="_blank">@sugarat/theme</a></p>
 
 [![code style](https://antfu.me/badge-code-style.svg)](https://github.com/antfu/eslint-config)
@@ -9,7 +9,6 @@
 这是一个 monorepo 仓库，目前有如下四个部分
 * [blogpress](./packages/blogpress/)：博客内容本身
 * [@sugarat/theme](./packages/theme/)：博客分离出的通用VitePress主题
-* [@sugarat/theme-shared](./packages/shared/)：VitePress 主题相关的工具方法
 * [创建主题模板项目CLI](./packages/create-theme/)：用于快速创建和作者一样风格的博客
 * [vitepress-plugin-pagefind](./packages/vitepress-plugin-pagefind/)：基于pagefind实现的VitePress离线全文搜索支持插件
 * [vitepress-plugin-rss](./packages/vitepress-plugin-rss/)：基于 feed 实现的 VitePress RSS 支持插件
@@ -54,54 +53,29 @@ pnpm dev:theme
 ```
 
 ## :pencil:关于内容
-大前端开发相关知识，包含但不限于前端
+代码的那些事
 
-记录面试中所遇的问题，并整理相关知识点，分模块进行了梳理
+记录所遇的问题，并整理相关知识点，分模块进行了梳理
 
-## :speak_no_evil:[关于笔者](./docs/aboutme.md)
-21年毕业，目前就职于美团，热爱大前端开发技术
+## :speak_no_evil:[关于笔者](./packages/blogpress/aboutme.md)
+2006年毕业，40岁大叔，目前热爱大前端开发技术
 
 热爱开源，乐于分享
 
-![图片](https://img.cdn.sugarat.top/mdImg/MTYwNDcyMTQ4NTMyOA==604721485328)
+![图片](/packages/blogpress/digital_pharmaceutical.jpg)
 
 ## :link:个人相关链接
 
-* [粥里有勺糖●博客园](https://www.cnblogs.com/roseAT/)
-* [ATQQ●GitHub](https://github.com/ATQQ)
-* [ES6笔记●GITBOOK](https://sugar-js.gitbook.io/-1/)
-* [blog●GitBook](https://sugar-at.gitbook.io/blog-article/)
-* [掘金](https://juejin.im/user/1028798615918983)
+* [代码收容所●博客园](https://www.cnblogs.com/68681395/)
 
 ## :phone:联系我
 如对博客内容，知识，排版等有疑问或者建议，欢迎邮件和我联系
 
-**邮箱:engineerzjl@foxmail.com**
+**邮箱:happycoder@foxmail.com**
 
 ![公众号](packages/blogpress/public/mp-code.png)
 
 ## :coffee:赞赏
-|                                  微信                                   |                                微信赞赏                                 |                                 支付宝                                  |
-| :---------------------------------------------------------------------: | :---------------------------------------------------------------------: | :---------------------------------------------------------------------: |
-| ![](https://img.cdn.sugarat.top/mdImg/MTY1MTU0NzQ0MjMzNA==651547442334) | ![](https://img.cdn.sugarat.top/mdImg/MTY0Nzc1NTYyOTE5Mw==647755629193) | ![](https://img.cdn.sugarat.top/mdImg/MTY1MTU0NzQyOTg0OA==651547429848) |
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=atqq/sugar-blog&type=Date)](https://star-history.com/#atqq/sugar-blog&Date)
-
-## Stargazers over time
-[![Stargazers over time](https://starchart.cc/ATQQ/sugar-blog.svg?variant=adaptive)](https://starchart.cc/ATQQ/sugar-blog)
-
-## Project Status
-
-![status](https://repobeats.axiom.co/api/embed/49625195d138fdaccc82ef70c9645d9a85afda5f.svg "Repobeats analytics image")
-
-## Contributors
-
-Thanks to all the contributors!
-
-<a href="https://github.com/atqq/sugar-blog/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=atqq/sugar-blog" />
-</a>
-
-Made with [contrib.rocks](https://contrib.rocks).
+ |                  微信赞赏                   | 微信赞赏 |
+ | :-----------------------------------------: | :----: |
+ | ![](/packages/blogpress/public/donate1.png) | ![](/packages/blogpress/public/donate1.png)  |


### PR DESCRIPTION
Change the blog title from "粥里有勺糖" to "代码收容所" and update the tagline to reflect a focus on code-related topics. Remove the section on theme development and update links and images to reflect the new blog direction. Make various clean-up changes to the markdown content, including fixing image paths and updating personal information.

BREAKING CHANGE: The blog title and descriptions have been updated, which may affect external links and references to the previous title.