### PR TITLE
fix(github-actions): change string literals to integers in delete-wor…

### DIFF
--- a/.github/workflows/delete-workflows.yml
+++ b/.github/workflows/delete-workflows.yml
@@ -10,11 +10,11 @@ on:
       days:
         description: Number of days.
         required: true
-        default: 0
+        default: '0'
       minimum_runs:
         description: The minimum runs to keep for each workflow.
         required: true
-        default: 1
+        default: '1'
       delete_workflow_pattern:
         description: The name or filename of the workflow. if not set then it will target all workflows.
         required: false


### PR DESCRIPTION
…kflows.yml

Previously, default values for `days` and `minimum_runs` in `delete-workflows.yml` were string literals. This update changes them to integers as required by the GitHub Actions workflow syntax for better consistency and functionality.