### PR TITLE
```plaintext

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@changesets/cli": "^2.27.7",
     "@types/bun": "^1.1.6",
     "@types/node": "^20.14.10",
+    "@types/vue": "^2.0.0",
     "eslint": "^9.6.0",
     "eslint-plugin-todo-ddl": "^1.1.1",
     "json5": "^2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@types/node':
         specifier: ^20.14.10
         version: 20.14.10
+      '@types/vue':
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@5.5.3)
       eslint:
         specifier: ^9.6.0
         version: 9.6.0
@@ -1010,6 +1013,10 @@ packages:
 
   '@types/unist@3.0.2':
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
+
+  '@types/vue@2.0.0':
+    resolution: {integrity: sha512-WDElkBv/o4lVwu6wYHB06AXs4Xo2fwDjJUpvPRc1QQdzkUSiGFjrYuSCy8raxLE5FObgKq8ND7R5gSZTFLK60w==}
+    deprecated: This is a stub types definition for vuejs (https://github.com/vuejs/vue). vuejs provides its own type definitions, so you don't need @types/vue installed!
 
   '@types/web-bluetooth@0.0.16':
     resolution: {integrity: sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ==}
@@ -4468,6 +4475,12 @@ snapshots:
   '@types/unist@2.0.10': {}
 
   '@types/unist@3.0.2': {}
+
+  '@types/vue@2.0.0(typescript@5.5.3)':
+    dependencies:
+      vue: 3.4.31(typescript@5.5.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@types/web-bluetooth@0.0.16': {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,9 +11,7 @@
     },
     "target": "esnext",
     "types": [
-      "vue",
-      "@vue/runtime-core",
-      "@vue/runtime-dom",
+      "@types/vue",
       "typescript-eslint"
     ],
     "jsx": "preserve",


### PR DESCRIPTION
移除vue类型自动引用并添加@types/vue依赖

通过移除tsconfig中的"vue"、"@vue/runtime-core"和"@vue/runtime-dom"类型引用，并添加"@types/vue"作为项目依赖，解决了类型定义问题。这样可以确保项目仅依赖于显式声明的类型定义，提高类型安全性和可维护性。
```